### PR TITLE
Patch out rand() function usages

### DIFF
--- a/src/comsock.c
+++ b/src/comsock.c
@@ -111,7 +111,7 @@ natsSock_ShuffleIPs(natsSockCtx *ctx, struct addrinfo **tmp, int tmpSize, struct
     // Shuffle the array
     for (i=0; i<count; i++)
     {
-        j = rand() % (i + 1);
+        j = _rand32() % (i + 1);
         p = ips[i];
         ips[i] = ips[j];
         ips[j] = p;

--- a/src/conn.c
+++ b/src/conn.c
@@ -1564,7 +1564,7 @@ _doReconnect(void *arg)
             {
                 sleepTime = nc->opts->reconnectWait;
                 if (jitter > 0)
-                    sleepTime += rand() % jitter;
+                    sleepTime += _rand32() % jitter;
             }
             natsCondition_TimedWait(nc->reconnectCond, nc->mu, sleepTime);
         }

--- a/src/nuid.c
+++ b/src/nuid.c
@@ -25,11 +25,13 @@ static uint32_t carry = 362436;     // must be limited with CMWC_C_MAX (we will 
 static uint32_t
 _rand32(void)
 {
-    uint32_t result = 0;
-    result = rand();
-    result <<= 16;
-    result |= rand();
-    return result;
+    union {
+        unsigned int i;
+        unsigned char c[sizeof(unsigned int)];
+    } u;
+
+    RAND_bytes(u.c, sizeof(u.c));
+    return u.i;
 }
 
 // Init all engine parts with seed

--- a/src/nuid.c
+++ b/src/nuid.c
@@ -22,7 +22,7 @@ static uint32_t Q[CMWC_CYCLE];
 static uint32_t carry = 362436;     // must be limited with CMWC_C_MAX (we will reinit it with seed)
 
 // Make 32 bit random number (some systems use 16 bit RAND_MAX)
-static uint32_t
+uint32_t
 _rand32(void)
 {
     union {

--- a/src/nuid.h
+++ b/src/nuid.h
@@ -18,6 +18,8 @@
 
 #define NUID_BUFFER_LEN (12 + 10)
 
+uint32_t _rand32(void);
+
 // Seed sequential random with math/random and current time and generate crypto prefix.
 natsStatus
 natsNUID_init(void);

--- a/src/srvpool.c
+++ b/src/srvpool.c
@@ -195,7 +195,7 @@ _shufflePool(natsSrvPool *pool, int offset)
 
     for (i = offset; i < pool->size; i++)
     {
-        j = offset + rand() % (i + 1 - offset);
+        j = offset + _rand32() % (i + 1 - offset);
         tmp = pool->srvrs[i];
         pool->srvrs[i] = pool->srvrs[j];
         pool->srvrs[j] = tmp;


### PR DESCRIPTION
Using rand() is not allowed in ClickHouse. Replace it with RAND_bytes from OpenSSL.